### PR TITLE
BUG-116943 Workaround for AMBARI-25136 (ignores rack_info)

### DIFF
--- a/src/main/groovy/com/sequenceiq/ambari/client/services/BlueprintService.groovy
+++ b/src/main/groovy/com/sequenceiq/ambari/client/services/BlueprintService.groovy
@@ -296,7 +296,7 @@ trait BlueprintService extends ClusterService {
    * @param hostsWithRackInfo list of hosts in form of FQDN with rack info
    */
   def int addHostsAndRackInfoWithBlueprint(String bpName, String hostGroup, Map<String, String> hostsWithRackInfo) throws HttpResponseException {
-    def hostMap = hostsWithRackInfo.collect { ["blueprint": bpName, "host_group": hostGroup, "host_name": it.key, "rack_info": it.value] }
+    def hostMap = hostsWithRackInfo.collect { ["blueprint": bpName, "host_group": hostGroup, "host_name": it.key, "Hosts/rack_info": it.value] }
     def json = new JsonBuilder(hostMap).toPrettyString()
     ambari.post(path: "clusters/${getClusterName()}/hosts", body: json, {
       utils.getRequestId(it)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ambari 2.6.x ignores `rack_info` provided in scale request (fixed in [AMBARI-25136](https://issues.apache.org/jira/browse/AMBARI-25136)).  All versions of Ambari accept `Hosts/rack_info`, though, so this change proposes to use the longer form.

## How was this patch tested?

Tested scale operation on local cluster with Ambari 2.6.2 and 2.7.3:

```groovy
AmbariClient client = new AmbariClient('localhost', 8080)
client.addHostsAndRackInfoWithBlueprint("blue", "node", ["c7402.ambari.apache.org": "/rack/a"])
```

```
$ curl "http://${AMBARI_SERVER}:8080/api/v1/clusters/TEST/hosts/c7402.ambari.apache.org?fields=Hosts/rack_info"
{
  "Hosts" : {
    "cluster_name" : "TEST",
    "host_name" : "c7402.ambari.apache.org",
    "rack_info" : "/rack/a"
  }
}
```