### PR TITLE
AmbariClientMain fails to run with arguments

### DIFF
--- a/src/main/groovy/com/sequenceiq/ambari/main/AmbariClientMain.groovy
+++ b/src/main/groovy/com/sequenceiq/ambari/main/AmbariClientMain.groovy
@@ -23,7 +23,7 @@ class AmbariClientMain {
   public static void main(String[] args) {
     def host = 'localhost'
     def port = '8080'
-    if (args.size == 2) {
+    if (args.length == 2) {
       host = args[0]
       port = args[1]
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allow running `AmbariClientMain` with arguments to specify Ambari host and port.  It already handles the arguments, but fails with exception if they are provided:

```
$ java com.sequenceiq.ambari.main.AmbariClientMain "c7401.ambari.apache.org" "8080"
Exception in thread "main" groovy.lang.MissingPropertyException: Exception evaluating property 'size' for java.util.Arrays$ArrayList, Reason: groovy.lang.MissingPropertyException: No such property: size for class: java.lang.String
	at org.codehaus.groovy.runtime.DefaultGroovyMethods.getAtIterable(DefaultGroovyMethods.java:7477)
	at org.codehaus.groovy.runtime.DefaultGroovyMethods.getAt(DefaultGroovyMethods.java:7466)
	at groovy.lang.MetaClassImpl$9.getProperty(MetaClassImpl.java:1982)
	at org.codehaus.groovy.runtime.callsite.GetEffectivePojoPropertySite.getProperty(GetEffectivePojoPropertySite.java:64)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callGetProperty(AbstractCallSite.java:296)
	at com.sequenceiq.ambari.main.AmbariClientMain.main(AmbariClientMain.groovy:26)
```

Thanks to @schfeca75 for pointing out the problem.

## How was this patch tested?

```
$ java com.sequenceiq.ambari.main.AmbariClientMain "c7401.ambari.apache.org" "8080"
...

  clusterList:
[2] TEST:HDP-2.6

  hostsList:
c7401.ambari.apache.org [HEALTHY] 192.168.74.101 centos7:x86_64
c7402.ambari.apache.org [HEALTHY] 192.168.74.102 centos7:x86_64

...
```