### PR TITLE
ENGESC-6437. Handle empty response for non-patched Ambari server

### DIFF
--- a/src/main/groovy/com/sequenceiq/ambari/client/services/ServiceAndHostService.groovy
+++ b/src/main/groovy/com/sequenceiq/ambari/client/services/ServiceAndHostService.groovy
@@ -297,10 +297,12 @@ trait ServiceAndHostService extends ClusterService {
     def result = [:]
     def query = forceMetricsFetch ? 'force_metrics_fetch=true' : ''
     def response = utils.slurp("clusters/${getClusterName()}/services/HDFS/components/NAMENODE", 'metrics/dfs/namenode/DecomNodes', query)
-    def nodes = slurper.parseText(response?.metrics?.dfs?.namenode?.DecomNodes)
-    if (nodes) {
-      nodes.each {
-        result << [(it.key): it.value.underReplicatedBlocks as Long]
+    if (!forceMetricsFetch || response != null) {
+      def nodes = slurper.parseText(response?.metrics?.dfs?.namenode?.DecomNodes)
+      if (nodes) {
+        nodes.each {
+          result << [(it.key): it.value.underReplicatedBlocks as Long]
+        }
       }
     }
     result


### PR DESCRIPTION
 seems like for non-patched ambari, if you apply `force_metrics_fetch`, although the response status code can be 200, the response text is fully empty, that can cause an exception with the slurper parseText call.